### PR TITLE
update to index page of contract hierarchy

### DIFF
--- a/_docs/developers/contract-deploying.md
+++ b/_docs/developers/contract-deploying.md
@@ -2,7 +2,7 @@
 title: Deploying FIO Contracts
 description: Deploying FIO contracts 
 redirect_from:
-   - /docs/developers/smartcontracts
+   - /docs/developers/contract
 
 ---
 

--- a/_docs/developers/contract-documenting.md
+++ b/_docs/developers/contract-documenting.md
@@ -2,7 +2,7 @@
 title: Documenting Changes for Deployment
 description: Guidelines for Documenting Changes for Deployment
 redirect_from:
-    - /docs/developers/smartcontracts
+    - /docs/developers/contract
 
 ---
 # Documenting Changes for Deployment

--- a/_docs/developers/contract-newcontracts.md
+++ b/_docs/developers/contract-newcontracts.md
@@ -2,7 +2,7 @@
 title: New FIO Contracts
 description: Information about adding new FIO contracts to the development environment
 redirect_from:
-    - /docs/developers/smartcontracts
+    - /docs/developers/contract
 
 ---
 

--- a/_docs/developers/contract.md
+++ b/_docs/developers/contract.md
@@ -13,6 +13,6 @@ redirect_from:
 
 |Content|Summary|
 |---|---|
-|[Guidelines for Documenting Changes]({{site.baseurl}}/docs/developers/smartcontracts/documenting) |Describes documentation deliverables required of developers for any changes and additions to smart contracts.|
-|[Creating New Contracts]({{site.baseurl}}/docs/developers/smartcontracts/newcontracts)|Provides documentation for the process of creating new contracts.|
-|[Deploying Changes to Contracts]({{site.baseurl}}/docs/developers/smartcontracts/deploying)|Provides documentation for the process of deploying changes to contracts, including guidelines for setting up a dev/test environment and sample commands. |
+|[Guidelines for Documenting Changes]({{site.baseurl}}/docs/developers/contract-documenting.md) |Describes documentation deliverables required of developers for any changes and additions to smart contracts.|
+|[Creating New Contracts]({{site.baseurl}}/docs/developers/contract-newcontracts.md)|Provides documentation for the process of creating new contracts.|
+|[Deploying Changes to Contracts]({{site.baseurl}}/docs/developers/contract-deploying.md)|Provides documentation for the process of deploying changes to contracts, including guidelines for setting up a dev/test environment and sample commands. |

--- a/_docs/developers/contract.md
+++ b/_docs/developers/contract.md
@@ -2,7 +2,7 @@
 title: Overview of FIO Contracts
 description: Overview of FIO contracts in the development environment
 redirect_from:
-    - /docs/developers/smartcontracts
+    - /docs/developers/contract
 ---
 
 # Overview of FIO Contracts Development

--- a/_docs/developers/contract.md
+++ b/_docs/developers/contract.md
@@ -13,6 +13,6 @@ redirect_from:
 
 |Content|Summary|
 |---|---|
-|[Guidelines for Documenting Changes]({{site.baseurl}}/docs/developers/contract-documenting.md) |Describes documentation deliverables required of developers for any changes and additions to smart contracts.|
-|[Creating New Contracts]({{site.baseurl}}/docs/developers/contract-newcontracts.md)|Provides documentation for the process of creating new contracts.|
-|[Deploying Changes to Contracts]({{site.baseurl}}/docs/developers/contract-deploying.md)|Provides documentation for the process of deploying changes to contracts, including guidelines for setting up a dev/test environment and sample commands. |
+|[Guidelines for Documenting Changes]({{site.baseurl}}/docs/developers/contract-documenting) |Describes documentation deliverables required of developers for any changes and additions to smart contracts.|
+|[Creating New Contracts]({{site.baseurl}}/docs/developers/contract-newcontracts)|Provides documentation for the process of creating new contracts.|
+|[Deploying Changes to Contracts]({{site.baseurl}}/docs/developers/contract-deploying)|Provides documentation for the process of deploying changes to contracts, including guidelines for setting up a dev/test environment and sample commands. |


### PR DESCRIPTION
This fixes links on the index page (currently throwing a 404 error)